### PR TITLE
Add random_fully support

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   has_feature :icmp_match
   has_feature :owner
   has_feature :state_match
+  has_feature :random_fully
   has_feature :reject_type
   has_feature :log_level
   has_feature :log_prefix
@@ -103,6 +104,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     proto: '-p',
     queue_num: '--queue-num',
     queue_bypass: '--queue-bypass',
+    random_fully: '--random-fully',
     rdest: '--rdest',
     reap: '--reap',
     recent: '-m recent',

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -17,6 +17,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
   has_feature :icmp_match
   has_feature :owner
   has_feature :state_match
+  has_feature :random_fully
   has_feature :reject_type
   has_feature :log_level
   has_feature :log_prefix
@@ -100,6 +101,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     proto: '-p',
     queue_num: '--queue-num',
     queue_bypass: '--queue-bypass',
+    random_fully: '--random-fully',
     random: '--random',
     rdest: '--rdest',
     reap: '--reap',
@@ -177,6 +179,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :isfragment,
     :log_uid,
     :random,
+    :random_fully,
     :rdest,
     :reap,
     :rsource,
@@ -295,7 +298,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :string_from, :string_to, :jump, :goto, :clusterip_new, :clusterip_hashmode,
     :clusterip_clustermac, :clusterip_total_nodes, :clusterip_local_node, :clusterip_hash_init, :queue_num, :queue_bypass,
     :nflog_group, :nflog_prefix, :nflog_range, :nflog_threshold, :clamp_mss_to_pmtu, :gateway,
-    :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random, :log_prefix,
+    :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random_fully, :random, :log_prefix,
     :log_level, :log_uid, :reject, :set_mark, :match_mark, :mss, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop,
     :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
@@ -479,7 +482,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     valrev = values.scan(%r{("([^"\\]|\\.)*"|\S+)}).transpose[0].reverse
 
     if keys.length != valrev.length
-      warning "Skipping unparsable iptables rule: keys (#{keys.length}) and values (#{valrev.length}) count mismatch on line: #{line}"
+      warning "Skipping unparsable iptables rule: keys (#{keys.length}) #{keys} and values (#{valrev.length}) #{valrev} count mismatch on line: #{line}"
       return
     end
 
@@ -532,6 +535,11 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
         next unless hash[dmark]
         hash[prop] = valid_dscp_classes[hash[dmark]]
       end
+    end
+
+    if hash[:random] == 'true-fully'
+      hash[:random_fully] = 'true'
+      hash.delete :random
     end
 
     # Convert booleans removing the previous cludge we did

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -40,6 +40,7 @@ Puppet::Type.newtype(:firewall) do
   feature :owner, 'Matching owners'
   feature :state_match, 'Matching stateful firewall states'
   feature :reject_type, 'The ability to control reject messages'
+  feature :random_fully, 'Fully randomize source port on SNAT and MASQUERADE rules with a PRNG'
   feature :log_level, 'The ability to control the log level'
   feature :log_prefix, 'The ability to add prefixes to log messages'
   feature :log_uid, 'Add UIDs to log messages'
@@ -584,7 +585,18 @@ Puppet::Type.newtype(:firewall) do
   newproperty(:random, required_features: :dnat) do
     desc <<-PUPPETCODE
       When using a jump value of "MASQUERADE", "DNAT", "REDIRECT", or "SNAT"
-      this boolean will enable randomized port mapping.
+      this boolean will enable randomized port mapping through a hash-based
+      algorithm
+    PUPPETCODE
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:random_fully, required_features: :random_fully) do
+    desc <<-PUPPETCODE
+      When using a jump value of "MASQUERADE" or "SNAT"
+      this boolean will enable fully randomized port mapping through a PRNG
+      requires iptables >= 1.6.2 and linux >= 3.14
     PUPPETCODE
 
     newvalues(:true, :false)


### PR DESCRIPTION
https://github.com/HubSpot/puppetlabs-firewall/pull/1 had worked great when I was testing on a non-kube node, however, it turns out that this PR `https://github.com/puppetlabs/puppetlabs-firewall/pull/789` broke 1.15 on kube nodes because the cni-ipvlan plugin has double quotes in its iptables rules and that PR made puppetlabs-firewall incapable of parsing a line like:
```
-A CNI-faa97d367f68b0b904990475 -d 172.18.32.52/32 -m comment --comment "name: \"cni-ipvlan-vpc-k8s\" id: \"cc0fab1289d3252fba85c73cf58edc336144ece76dbc243204b6ee7355647245\"" -j ACCEPT
```
so I just cherry-picked the 1.15 change onto the 1.14 tag so we can roll with 1.14 instead for now. 1.15 doesn't give us anything.

@hmcgonig @jeruane @tpetr